### PR TITLE
Update Invoke-PSGeoLocator.ps1

### DIFF
--- a/Invoke-PSGeoLocator.ps1
+++ b/Invoke-PSGeoLocator.ps1
@@ -3,11 +3,8 @@ $api = "< API key from https://ipapi.com/ >
 $headers = (Get-Content -Path $filePath -TotalCount 4 | Select -Skip 3) -replace '#Fields: ' -split ' '
 $headers += "city", "region", "country", "continent"
 
-$log = Get-Content $filePath | Select-String -Pattern '^#' -NotMatch
-$log | Add-Member -MemberType ScriptProperty -Name 'City' -Value {$null}
-$log | Add-Member -MemberType ScriptProperty -Name 'Region' -Value {$null}
-$log | Add-Member -MemberType ScriptProperty -Name 'Country' -Value {$null}
-$log | Add-Member -MemberType ScriptProperty -Name 'Continent' -Value {$null}
+$log = Get-Content $filePath | Select-String -Pattern '^#' -NotMatch | Select-Object *, City, Region, Country, Continent
+
 Remove-Variable address -ErrorAction SilentlyContinue
 
 $records = Get-Content $filePath | Select-String -Pattern '^#' -NotMatch | ConvertFrom-Csv -Delimiter ' ' -Header $headers


### PR DESCRIPTION
While using `Select-Object` to add properties to an existing object is not as explicit, Add-Member with its multiple pipelines is expensive, and commonly thought of as out-of-date style.